### PR TITLE
[private certificate authority] cert-manager and trust-manager deployment

### DIFF
--- a/integration/apps/cert-manager.yaml
+++ b/integration/apps/cert-manager.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-9"
+  finalizers:
+   - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    chart: cert-manager
+    repoURL: https://charts.jetstack.io
+    targetRevision: v1.14.5
+    helm:
+      parameters:
+      - name: "installCRDs"
+        value: "true"
+        forceString: true # ensures that value is treated as a string
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/integration/apps/setup-ca-and-bundle.yaml
+++ b/integration/apps/setup-ca-and-bundle.yaml
@@ -1,0 +1,80 @@
+# Setup the private certificate authority
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-9"
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-selfsigned-ca
+  namespace: cert-manager
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-9"
+spec:
+  isCA: true
+  commonName: my-selfsigned-ca
+  secretName: root-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: private-ca-issuer
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-9"
+spec:
+  ca:
+    secretName: root-secret
+---
+# Create a bundle including the Kubernetes cluster root certificate and our
+# private certificate authority root certificate
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: ca-bundle
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-9"
+spec:
+  sources:
+  # Include a bundle of publicly trusted certificates which can be
+  # used to validate most TLS certificates on the internet, such as
+  # those issued by Let's Encrypt, Google, Amazon and others.
+  - useDefaultCAs: true
+
+  # A ConfigMap in the "trust" namespace
+  - configMap:
+      name: "kube-root-ca.crt"
+      key: "ca.crt"
+
+  # A Secret in the "trust" namespace
+  - secret:
+      name: "root-secret"
+      key: "ca.crt"
+
+  target:
+    # Sync the bundle to a ConfigMap and Secret called `ca-bundle` in every
+    # namespace that has the label `create-ca-bundle=true` (and if the Secret
+    # belongs to the list of authorized secrets).
+    # All ConfigMaps will include a PEM-formatted bundle, here named `ca.crt`.
+    configMap:
+      key: "ca.crt"
+    secret:
+      key: "ca.crt"
+    namespaceSelector:
+      matchLabels:
+        create-ca-bundle: "true"

--- a/integration/apps/trust-manager.yaml
+++ b/integration/apps/trust-manager.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trust-manager
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-9"
+  finalizers:
+   - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    chart: trust-manager
+    repoURL: https://charts.jetstack.io
+    targetRevision: v0.9.2
+    helm:
+      valuesObject:
+        podDisruptionBudget:
+          enabled: true
+        replicaCount: 2
+        secretTargets:
+          enabled: true
+          authorizedSecrets:
+          - ca-bundle
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true


### PR DESCRIPTION
This PR is related to https://github.com/glaciation-heu/IceStream/issues/130 and includes the deployment of two services:
- cert-manager
- trust-manager

These service are a requirement for our deployment of Vault with TLS, the secure communication between MinIO and Vault, and the interaction with MinIO tenant without disabling the validation of TLS certificates by clients.

## cert-manager

source: [https://cert-manager.io/](https://cert-manager.io/)
> **cert-manager** is a powerful and extensible X.509 certificate controller for Kubernetes and OpenShift workloads. It  will obtain certificates from a variety of Issuers, both popular public Issuers as well as private Issuers, and ensure the certificates are valid and up-to-date, and will attempt to renew certificates at a configured time before expiry.

This service allows us to easily create TLS certificates to ensure secure communications within the cluster.

## trust-manager

source: [https://cert-manager.io/docs/trust/trust-manager/](https://cert-manager.io/docs/trust/trust-manager/)
> **trust-manager** is the easiest way to manage trust bundles in Kubernetes and OpenShift clusters. It orchestrates bundles of trusted X.509 certificates which are primarily used for validating certificates during a TLS handshake but can be used in other situations, too.

This service allows us to easily share the integration Kubernetes cluster root CA and our private CA root certificates within the cluster to ensure they are trusted by pods. This avoids the necessity to disable the validation of TLS certificates to enable the communication over TLS between pods of the cluster.