### PR TITLE
[replicator] k8s controller for secrets synchronization across namespaces

### DIFF
--- a/integration/apps/replicator.yaml
+++ b/integration/apps/replicator.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: replicator
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-9"
+  finalizers:
+   - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    chart: kubernetes-replicator
+    repoURL: https://helm.mittwald.de
+    targetRevision: 2.9.2
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: replicator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
PR related to https://github.com/glaciation-heu/IceStream/issues/130.

Kubernetes controller for synchronizing secrets & config maps across namespaces.

It supports:
- push-based replication: "push out" the secrets, configmaps, roles and rolebindings into namespaces when new namespaces are created or when the secret/configmap/roles/rolebindings changes
- pull-based replication: makes it possible to create a secret/configmap/role/rolebindings and select a "source" resource from which the data is replicated from

We use it for the successful deployment of the data wrapping service. It allows us to authenticate the [MinIO KES service](https://github.com/minio/kes) with the Hashicorp Vault Keystore by replicating the service account token of the MinIO KES service to the Vault namespace.