### PR TITLE
[vault] secret management service

### DIFF
--- a/integration/apps/local-path-storage.yaml
+++ b/integration/apps/local-path-storage.yaml
@@ -1,169 +1,25 @@
-apiVersion: v1
-kind: Namespace
+apiVersion: argoproj.io/v1alpha1
+kind: Application
 metadata:
   name: local-path-storage
+  namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "-1"
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: local-path-provisioner-service-account
-  namespace: local-path-storage
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: local-path-provisioner-role
-  namespace: local-path-storage
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
-rules:
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: local-path-provisioner-role
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
-rules:
-  - apiGroups: [""]
-    resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods", "pods/log"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
-    verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: local-path-provisioner-bind
-  namespace: local-path-storage
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: local-path-provisioner-role
-subjects:
-  - kind: ServiceAccount
-    name: local-path-provisioner-service-account
-    namespace: local-path-storage
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: local-path-provisioner-bind
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: local-path-provisioner-role
-subjects:
-  - kind: ServiceAccount
-    name: local-path-provisioner-service-account
-    namespace: local-path-storage
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: local-path-provisioner
-  namespace: local-path-storage
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/compare-options: ServerSideDiff=true  
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: local-path-provisioner
-  template:
-    metadata:
-      labels:
-        app: local-path-provisioner
-    spec:
-      serviceAccountName: local-path-provisioner-service-account
-      containers:
-        - name: local-path-provisioner
-          image: rancher/local-path-provisioner:v0.0.26
-          imagePullPolicy: IfNotPresent
-          command:
-            - local-path-provisioner
-            - --debug
-            - start
-            - --config
-            - /etc/config/config.json
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/config/
-          env:
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-      volumes:
-        - name: config-volume
-          configMap:
-            name: local-path-config
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: local-path
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
-provisioner: rancher.io/local-path
-volumeBindingMode: WaitForFirstConsumer
-reclaimPolicy: Delete
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: local-path-config
-  namespace: local-path-storage
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
-data:
-  config.json: |-
-    {
-            "nodePathMap":[
-            {
-                    "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
-                    "paths":["/opt/local-path-provisioner"]
-            }
-            ]
-    }
-  setup: |-
-    #!/bin/sh
-    set -eu
-    mkdir -m 0777 -p "$VOL_DIR"
-  teardown: |-
-    #!/bin/sh
-    set -eu
-    rm -rf "$VOL_DIR"
-  helperPod.yaml: |-
-    apiVersion: v1
-    kind: Pod
-    metadata:
-      name: helper-pod
-    spec:
-      priorityClassName: system-node-critical
-      tolerations:
-        - key: node.kubernetes.io/disk-pressure
-          operator: Exists
-          effect: NoSchedule
-      containers:
-      - name: helper-pod
-        image: busybox
-        imagePullPolicy: IfNotPresent
+  destination:
+    namespace: default
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    repoURL: https://github.com/glaciation-heu/gitops-deployments
+    path: integration/apps/local-path-storage
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+     prune: true
+     selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/integration/apps/local-path-storage.yaml
+++ b/integration/apps/local-path-storage.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/compare-options: ServerSideDiff=true  
+    argocd.argoproj.io/sync-wave: "-1"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/integration/apps/local-path-storage.yaml
+++ b/integration/apps/local-path-storage.yaml
@@ -1,25 +1,169 @@
-apiVersion: argoproj.io/v1alpha1
-kind: Application
+apiVersion: v1
+kind: Namespace
 metadata:
   name: local-path-storage
-  namespace: argocd
   annotations:
-    argocd.argoproj.io/compare-options: ServerSideDiff=true  
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
+    argocd.argoproj.io/sync-wave: "-1"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: local-path-provisioner-role
+  namespace: local-path-storage
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-path-provisioner-role
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: local-path-provisioner-bind
+  namespace: local-path-storage
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: local-path-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: local-path-provisioner-service-account
+    namespace: local-path-storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-path-provisioner-bind
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: local-path-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: local-path-provisioner-service-account
+    namespace: local-path-storage
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-path-provisioner
+  namespace: local-path-storage
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
-  destination:
-    namespace: default
-    server: https://kubernetes.default.svc
-  project: default
-  source:
-    repoURL: https://github.com/glaciation-heu/gitops-deployments
-    path: integration/apps/local-path-storage
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-     prune: true
-     selfHeal: true
-    syncOptions:
-      - CreateNamespace=true
-      - ServerSideApply=true
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-path-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-path-provisioner
+    spec:
+      serviceAccountName: local-path-provisioner-service-account
+      containers:
+        - name: local-path-provisioner
+          image: rancher/local-path-provisioner:v0.0.26
+          imagePullPolicy: IfNotPresent
+          command:
+            - local-path-provisioner
+            - --debug
+            - start
+            - --config
+            - /etc/config/config.json
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config/
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      volumes:
+        - name: config-volume
+          configMap:
+            name: local-path-config
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+provisioner: rancher.io/local-path
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+data:
+  config.json: |-
+    {
+            "nodePathMap":[
+            {
+                    "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+                    "paths":["/opt/local-path-provisioner"]
+            }
+            ]
+    }
+  setup: |-
+    #!/bin/sh
+    set -eu
+    mkdir -m 0777 -p "$VOL_DIR"
+  teardown: |-
+    #!/bin/sh
+    set -eu
+    rm -rf "$VOL_DIR"
+  helperPod.yaml: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: helper-pod
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
+      containers:
+      - name: helper-pod
+        image: busybox
+        imagePullPolicy: IfNotPresent

--- a/integration/apps/local-path-storage/local-path-storage.yaml
+++ b/integration/apps/local-path-storage/local-path-storage.yaml
@@ -2,30 +2,35 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: local-path-storage
-
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-path-provisioner-service-account
   namespace: local-path-storage
-
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: local-path-provisioner-role
   namespace: local-path-storage
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-path-provisioner-role
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 rules:
   - apiGroups: [""]
     resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods", "pods/log"]
@@ -39,13 +44,14 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: local-path-provisioner-bind
   namespace: local-path-storage
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -54,12 +60,13 @@ subjects:
   - kind: ServiceAccount
     name: local-path-provisioner-service-account
     namespace: local-path-storage
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-path-provisioner-bind
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -68,13 +75,14 @@ subjects:
   - kind: ServiceAccount
     name: local-path-provisioner-service-account
     namespace: local-path-storage
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: local-path-provisioner
   namespace: local-path-storage
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   replicas: 1
   selector:
@@ -108,22 +116,24 @@ spec:
         - name: config-volume
           configMap:
             name: local-path-config
-
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-path
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 provisioner: rancher.io/local-path
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
-
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: local-path-config
   namespace: local-path-storage
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.json: |-
     {

--- a/integration/apps/minio-kes-sa-and-secrets.yaml
+++ b/integration/apps/minio-kes-sa-and-secrets.yaml
@@ -42,13 +42,3 @@ metadata:
     replicator.v1.mittwald.de/replication-allowed: "true"
     replicator.v1.mittwald.de/replication-allowed-namespaces: "vault"
 type: kubernetes.io/service-account-token
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: minio-kes-secret
-  namespace: vault
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
-    replicator.v1.mittwald.de/replicate-from: minio-tenant/minio-kes-secret
-data: {}

--- a/integration/apps/minio-kes-sa-and-secrets.yaml
+++ b/integration/apps/minio-kes-sa-and-secrets.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minio-tenant
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    create-ca-bundle: "true"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: minio-kes
+  namespace: minio-tenant
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: role-tokenreview-binding
+  namespace: minio-tenant
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: minio-kes
+  namespace: minio-tenant
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-kes-secret
+  namespace: minio-tenant
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    kubernetes.io/service-account.name: minio-kes
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "vault"
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-kes-secret
+  namespace: vault
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    replicator.v1.mittwald.de/replicate-from: minio-tenant/minio-kes-secret
+data: {}

--- a/integration/apps/vault.yaml
+++ b/integration/apps/vault.yaml
@@ -54,6 +54,7 @@ metadata:
   name: vault
   namespace: argocd
   annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
     argocd.argoproj.io/sync-wave: "-1"
   finalizers:
    - resources-finalizer.argocd.argoproj.io

--- a/integration/apps/vault.yaml
+++ b/integration/apps/vault.yaml
@@ -64,11 +64,78 @@ spec:
     chart: vault
     targetRevision: 0.28.0
     helm:
-      valueFiles:
-      - $values/values/vault-ha-values.yaml
-  - repoURL: 'https://github.com/unibg-seclab/glaciation-gitops-test.git'
-    targetRevision: main
-    ref: values
+      valuesObject:
+        global:
+          enabled: true
+          tlsDisable: false
+        injector:
+          enabled: false
+        server:
+          enabled: true
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m
+            limits:
+              memory: 256Mi
+              cpu: 250m
+          extraEnvironmentVars:
+            VAULT_CACERT: /vault/userconfig/vault-tls/ca.crt
+            VAULT_TLSCERT: /vault/userconfig/vault-tls/tls.crt
+            VAULT_TLSKEY: /vault/userconfig/vault-tls/tls.key
+          volumes:
+            - name: userconfig-vault-tls
+              secret:
+                defaultMode: 420
+                secretName: vault-tls
+          volumeMounts:
+            - mountPath: /vault/userconfig/vault-tls
+              name: userconfig-vault-tls
+              readOnly: true
+          standalone:
+            enabled: false
+          service:
+            enabled: true
+            type: NodePort
+            active:
+              enabled: false
+            standby:
+              enabled: false
+          dataStorage:
+            enabled: true
+            size: 10Gi
+            storageClass: local-path
+          auditStorage:
+            enabled: true
+            size: 10Gi
+            storageClass: local-path
+          ui:
+            enabled: true
+            serviceType: NodePort
+          affinity: ""
+          ha:
+            enabled: true
+            replicas: 3
+            raft:
+              enabled: true
+              setNodeId: true
+              config: |
+                disable_mlock = true
+                ui = true
+
+                listener "tcp" {
+                  address = "[::]:8200"
+                  cluster_address = "[::]:8201"
+                  tls_cert_file = "/vault/userconfig/vault-tls/tls.crt"
+                  tls_key_file  = "/vault/userconfig/vault-tls/tls.key"
+                  tls_client_ca_file = "/vault/userconfig/vault-tls/ca.crt"
+                }
+
+                storage "raft" {
+                  path = "/vault/data"
+                }
+
+                service_registration "kubernetes" {}
   destination:
     server: "https://kubernetes.default.svc"
     namespace: vault

--- a/integration/apps/vault.yaml
+++ b/integration/apps/vault.yaml
@@ -1,0 +1,231 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vault
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    create-ca-bundle: "true"
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: vault-certificate
+  namespace: vault
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  secretName: vault-tls
+  issuerRef:
+    name: private-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  subject:
+    organizations:
+      - system:nodes
+  commonName: system:node:*.vault.svc.cluster.local
+  isCA: false
+  # TODO: Try restricting usages to digital signature, key encipherment, and
+  # server auth
+  usages:
+  - digital signature
+  - key encipherment
+  - data encipherment
+  - server auth
+  - client auth
+  dnsNames:
+  - "*.vault-internal"
+  - "*.vault-internal.vault.svc.cluster.local"
+  - "*.vault"
+  - "vault-internal.vault.svc.cluster.local"
+  ipAddresses:
+  - 127.0.0.1
+  - 192.168.49.2
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vault
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+   - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+  - repoURL: https://helm.releases.hashicorp.com
+    chart: vault
+    targetRevision: 0.28.0
+    helm:
+      valueFiles:
+      - $values/values/vault-ha-values.yaml
+  - repoURL: 'https://github.com/unibg-seclab/glaciation-gitops-test.git'
+    targetRevision: main
+    ref: values
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: vault
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kes-policy
+  namespace: vault
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+data:
+  kes-policy.hcl: |
+    path "kv/data/minio-tenant/*" {
+      capabilities = [ "create", "read" ]
+    }
+    path "kv/metadata/minio-tenant/*" {
+      capabilities = [ "list", "delete" ]
+    }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: init-vault-cluster
+  namespace: vault
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  template:
+    spec:
+      containers:
+      - name: vault
+        image: hashicorp/vault:1.16.1
+        env:
+        - name: "SHARES"
+          value: "5"
+        - name: "THRESHOLD"
+          value: "3"
+        command:
+        - /bin/sh
+        - -c
+        - |
+          function unseal {
+              head -n $THRESHOLD /vault/cluster-keys |
+              while read line; do
+                vault operator unseal \
+                  -address=https://$1.vault-internal:8200 \
+                  $line;
+              done
+          }
+
+          echo '[*] Initialize HA Vault cluster'
+          # Wait for the startup of the Vault pods
+          sleep 30 # it does the job without requiring to create an ad hoc image
+          # TODO: Persist PGP encrypted Vault unseal keys somewhere outside the cluster
+          vault operator init \
+            -address=https://vault-0.vault-internal:8200 \
+            -key-shares=$SHARES \
+            -key-threshold=$THRESHOLD \
+            -format=json > /vault/response.json
+          # Extract unseal keys from the JSON response
+          awk '/"unseal_keys_b64": \[/{flag=1;next}/\]/{flag=0}flag' /vault/response.json | sed -n 's/\s*"\(.*\)".*/\1/p' > /vault/cluster-keys
+          unseal vault-0
+          vault operator raft join \
+            -address=https://vault-1.vault-internal:8200 \
+            -leader-ca-cert="$(cat /vault/userconfig/vault-tls/ca.crt)" \
+            -leader-client-cert="$(cat /vault/userconfig/vault-tls/tls.crt)" \
+            -leader-client-key="$(cat /vault/userconfig/vault-tls/tls.key)" \
+            https://vault-0.vault-internal:8200
+          unseal vault-1
+          vault operator raft join \
+            -address=https://vault-2.vault-internal:8200 \
+            -leader-ca-cert="$(cat /vault/userconfig/vault-tls/ca.crt)" \
+            -leader-client-cert="$(cat /vault/userconfig/vault-tls/tls.crt)" \
+            -leader-client-key="$(cat /vault/userconfig/vault-tls/tls.key)" \
+            https://vault-0.vault-internal:8200
+          unseal vault-2
+          echo -e '\n[*] Setup HA Vault cluster for integration with MinIO'
+          VAULT_ROOT_TOKEN=$(sed -n 's/\s*"root_token": "\(.*\)".*/\1/p' /vault/response.json)
+          vault login \
+            -address=https://vault-0.vault-internal:8200 \
+            $VAULT_ROOT_TOKEN
+          vault secrets enable \
+            -address=https://vault-0.vault-internal:8200 \
+            -version=2 \
+            kv
+          vault policy write \
+            -address=https://vault-0.vault-internal:8200 \
+            kes-policy /minio/kes/kes-policy.hcl
+          vault auth enable \
+            -address=https://vault-0.vault-internal:8200 \
+            kubernetes
+          vault write \
+            -address=https://vault-0.vault-internal:8200 \
+            auth/kubernetes/config \
+            token_reviewer_jwt="$(cat /minio/kes/service-account/token)" \
+            kubernetes_host="https://kubernetes.default.svc.cluster.local" \
+            kubernetes_ca_cert="$(cat /minio/kes/service-account/ca.crt)" \
+            issuer="https://kubernetes.default.svc.cluster.local"
+          vault write \
+            -address=https://vault-0.vault-internal:8200 \
+            auth/kubernetes/role/minio-kes \
+            bound_service_account_names=minio-kes \
+            bound_service_account_namespaces=minio-tenant \
+            policies=kes-policy \
+            ttl=1h
+        securityContext:
+          runAsUser: 100
+          runAsGroup: 1000
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+        volumeMounts:
+        - mountPath: /etc/ssl/certs/ca.crt
+          subPath: ca.crt
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /vault/userconfig/vault-tls
+          name: userconfig-vault-tls
+          readOnly: true
+        - mountPath: /minio/kes/service-account
+          name: minio-kes-service-account-token
+          readOnly: true
+        - mountPath: /minio/kes/kes-policy.hcl
+          subPath: kes-policy.hcl
+          name: kes-policy
+          readOnly: true
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 100
+        runAsGroup: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+      - name: ca-bundle
+        configMap:
+          defaultMode: 422
+          name: ca-bundle
+      - name: userconfig-vault-tls
+        secret:
+          defaultMode: 420
+          secretName: vault-tls
+      - name: minio-kes-service-account-token
+        secret:
+          defaultMode: 420
+          secretName: minio-kes-secret
+      - name: kes-policy
+        configMap:
+          defaultMode: 420
+          name: kes-policy
+  backoffLimit: 1

--- a/integration/apps/vault.yaml
+++ b/integration/apps/vault.yaml
@@ -7,6 +7,16 @@ metadata:
   labels:
     create-ca-bundle: "true"
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-kes-secret
+  namespace: vault
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    replicator.v1.mittwald.de/replicate-from: minio-tenant/minio-kes-secret
+data: {}
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/integration/apps/vault.yaml
+++ b/integration/apps/vault.yaml
@@ -97,7 +97,6 @@ spec:
             enabled: false
           service:
             enabled: true
-            type: NodePort
             active:
               enabled: false
             standby:
@@ -112,7 +111,22 @@ spec:
             storageClass: local-path
           ui:
             enabled: true
-            serviceType: NodePort
+          ingress:
+            enabled: true
+            ingressClassName: nginx
+            annotations:
+              # NOTE: To make sure the certificate is trusted by clients we should use
+              # something like Let's Encrypt
+              cert-manager.io/cluster-issuer: "private-ca-issuer"
+              nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+              nginx.ingress.kubernetes.io/ssl-redirect: "true"
+            tls:
+            - hosts:
+              - vault.integration
+              secretName: vault-ingress
+            hosts:
+            - host: vault.integration
+            activeService: false
           affinity: ""
           ha:
             enabled: true


### PR DESCRIPTION
This PR relates to https://github.com/glaciation-heu/IceStream/issues/130 and depends on https://github.com/glaciation-heu/gitops-deployments/pull/42 and https://github.com/glaciation-heu/gitops-deployments/pull/43.

The data wrapping service uses Hashicorp Vault for managing the keys used by MinIO for the server-side encryption of buckets and objects.

See the [documentation](https://github.com/glaciation-heu/IceStream/blob/main/data_wrapping_service/docs/architecture.md) of the data wrapping service architecture for additional details.

To ensure Vault can successfully deploy it needs a storage class available for the creation of persistent volumes, hence we had to anticipate the deployment of the existing storage class to the same ArgoCD wave of Vault.