### PR TITLE
Delete runtime status form manifests

### DIFF
--- a/integration/apps/ingresses/argocd.ingress.yaml
+++ b/integration/apps/ingresses/argocd.ingress.yaml
@@ -16,7 +16,3 @@ spec:
               number: 80
         path: /
         pathType: Prefix
-status:
-  loadBalancer:
-    ingress:
-    - ip: 10.1.14.160

--- a/integration/apps/ingresses/gatekeeper-policy-manager.ingress.yaml
+++ b/integration/apps/ingresses/gatekeeper-policy-manager.ingress.yaml
@@ -16,7 +16,3 @@ spec:
               number: 80
         path: /
         pathType: Prefix
-status:
-  loadBalancer:
-    ingress:
-    - ip: 10.1.14.160


### PR DESCRIPTION
The status part of manifests is a runtime data generated by k8s. We do not need it in our repo.