### PR TITLE
Add missing Java KeyStore to the CA bundle

### DIFF
--- a/integration/apps/security/setup-ca-and-bundle.yaml
+++ b/integration/apps/security/setup-ca-and-bundle.yaml
@@ -70,7 +70,11 @@ spec:
     # Sync the bundle to a ConfigMap and Secret called `ca-bundle` in every
     # namespace that has the label `create-ca-bundle=true` (and if the Secret
     # belongs to the list of authorized secrets).
-    # All ConfigMaps will include a PEM-formatted bundle, here named `ca.crt`.
+    # Beside the PEM-formatted bundle named `ca.crt`, we also require a bundle
+    # in JKS format.
+    additionalFormats:
+      jks:
+        key: "ca.jks"
     configMap:
       key: "ca.crt"
     secret:


### PR DESCRIPTION
The Spark history server mounts a Java KeyStore containing:

- publicly trusted certificate authorities (e.g., Let's Encrypt, Google, Amazon and others)
- K8s cluster certificate authority (used by the MinIO operator for generating the MinIO tenant certificates)
- our private certificate authority

The Spark history server needs this to be able to communicate with the MinIO tenant S3 API and, hence, read the Spark application events.

In the release of the data sanitization service, I forgot to update the trust-manager CA bundle with the addition of the Java KeyStore format, hindering the start of the spark history server. This PR fixes it.

