### PR TITLE
Disable TLS on multiple Ingresses

### DIFF
--- a/integration/apps/kernel/minio-tenant.yaml
+++ b/integration/apps/kernel/minio-tenant.yaml
@@ -130,15 +130,14 @@ spec:
             enabled: true
             ingressClassName: "nginx"
             annotations:
-              # NOTE: To make sure the certificate is trusted by clients we should use
-              # something like Let's Encrypt
-              cert-manager.io/cluster-issuer: "private-ca-issuer"
+            #   # NOTE: To make sure the certificate is trusted by clients we should use
+            #   # something like Let's Encrypt
+            #   cert-manager.io/cluster-issuer: "private-ca-issuer"
               nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-              nginx.ingress.kubernetes.io/ssl-redirect: "false"
-            tls:
-            - hosts:
-              - glaciation-tenant.integration
-              secretName: minio-tenant-ingress
+            # tls:
+            # - hosts:
+            #   - glaciation-tenant.integration
+            #   secretName: minio-tenant-ingress
             host: glaciation-tenant.integration
             path: /
             pathType: Prefix
@@ -146,15 +145,14 @@ spec:
             enabled: true
             ingressClassName: "nginx"
             annotations:
-              # NOTE: To make sure the certificate is trusted by clients we should use
-              # something like Let's Encrypt
-              cert-manager.io/cluster-issuer: "private-ca-issuer"
+            #   # NOTE: To make sure the certificate is trusted by clients we should use
+            #   # something like Let's Encrypt
+            #   cert-manager.io/cluster-issuer: "private-ca-issuer"
               nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-              nginx.ingress.kubernetes.io/ssl-redirect: "false"
-            tls:
-            - hosts:
-              - glaciation-tenant-console.integration
-              secretName: minio-tenant-console-ingress
+            # tls:
+            # - hosts:
+            #   - glaciation-tenant-console.integration
+            #   secretName: minio-tenant-console-ingress
             host: glaciation-tenant-console.integration
             path: /
             pathType: Prefix

--- a/integration/apps/security/data-sanitization-service.yaml
+++ b/integration/apps/security/data-sanitization-service.yaml
@@ -40,20 +40,19 @@ spec:
         ingress:
           enabled: true
           className: nginx
-          annotations:
-            # NOTE: To make sure the certificate is trusted by clients we should use
-            # something like Let's Encrypt
-            cert-manager.io/cluster-issuer: "private-ca-issuer"
-            nginx.ingress.kubernetes.io/ssl-redirect: "false"
+          # annotations:
+          #   # NOTE: To make sure the certificate is trusted by clients we should use
+          #   # something like Let's Encrypt
+          #   cert-manager.io/cluster-issuer: "private-ca-issuer"
           hosts:
           - host: data-sanitization.integration
             paths:
             - path: /
               pathType: Prefix
-          tls:
-          - hosts:
-            - data-sanitization.integration
-            secretName: data-sanitization-ingress
+          # tls:
+          # - hosts:
+          #   - data-sanitization.integration
+          #   secretName: data-sanitization-ingress
 
         resources:
           requests:

--- a/integration/apps/security/gatekeeper-policy-manager.yaml
+++ b/integration/apps/security/gatekeeper-policy-manager.yaml
@@ -18,15 +18,14 @@ spec:
         ingress:
           enabled: true
           ingressClassName: nginx
-          annotations:
-            # NOTE: To make sure the certificate is trusted by clients we should use
-            # something like Let's Encrypt
-            cert-manager.io/cluster-issuer: "private-ca-issuer"
-            nginx.ingress.kubernetes.io/ssl-redirect: "false"
-          tls:
-          - hosts:
-            - gpm.integration
-            secretName: gpm-ingress
+          # annotations:
+          #   # NOTE: To make sure the certificate is trusted by clients we should use
+          #   # something like Let's Encrypt
+          #   cert-manager.io/cluster-issuer: "private-ca-issuer"
+          # tls:
+          # - hosts:
+          #   - gpm.integration
+          #   secretName: gpm-ingress
           hosts:
           - host: gpm.integration
             paths:

--- a/integration/apps/security/spark-history-server.yaml
+++ b/integration/apps/security/spark-history-server.yaml
@@ -40,20 +40,19 @@ spec:
         ingress:
           enabled: true
           className: nginx
-          annotations:
-            # NOTE: To make sure the certificate is trusted by clients we should use
-            # something like Let's Encrypt
-            cert-manager.io/cluster-issuer: "private-ca-issuer"
-            nginx.ingress.kubernetes.io/ssl-redirect: "false"
+          # annotations:
+          #   # NOTE: To make sure the certificate is trusted by clients we should use
+          #   # something like Let's Encrypt
+          #   cert-manager.io/cluster-issuer: "private-ca-issuer"
           hosts:
           - host: spark-history-server.integration
             paths:
             - path: /
               pathType: Prefix
-          tls:
-          - hosts:
-            - spark-history-server.integration
-            secretName: spark-history-server-ingress
+          # tls:
+          # - hosts:
+          #   - spark-history-server.integration
+          #   secretName: spark-history-server-ingress
 
         resources:
           requests:

--- a/integration/apps/security/vault.yaml
+++ b/integration/apps/security/vault.yaml
@@ -125,15 +125,14 @@ spec:
             enabled: true
             ingressClassName: nginx
             annotations:
-              # NOTE: To make sure the certificate is trusted by clients we should use
-              # something like Let's Encrypt
-              cert-manager.io/cluster-issuer: "private-ca-issuer"
+            #   # NOTE: To make sure the certificate is trusted by clients we should use
+            #   # something like Let's Encrypt
+            #   cert-manager.io/cluster-issuer: "private-ca-issuer"
               nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-              nginx.ingress.kubernetes.io/ssl-redirect: "false"
-            tls:
-            - hosts:
-              - vault.integration
-              secretName: vault-ingress
+            # tls:
+            # - hosts:
+            #   - vault.integration
+            #   secretName: vault-ingress
             hosts:
             - host: vault.integration
             activeService: false


### PR DESCRIPTION
Previous attempt at making services accessible outside of the integration cluster in PR #113 was not successful (admittedly it actually made it worst, now not even http://gpm.integration is reachable).

So, with this patch, I am disabling TLS on multiple Ingresses entirely by commenting out the relevant bits of information. This is expected to improve the situation (at least for all those services that do not have an HTTPS backend).