### PR TITLE
added the config files for neo4j and decision engine

### DIFF
--- a/integration/apps/ai-decision-engine/decision-engine.yaml
+++ b/integration/apps/ai-decision-engine/decision-engine.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: idmg-decision-engine
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://idmg-pub.gitlab.io/helm-charts/
+    chart: cf
+    targetRevision: 0.*.*
+    helm:
+      # valuesObject:
+      #   ingressHostName: uc2-workload.integration
+  destination:
+    namespace: idmg
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+     prune: true
+     selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/integration/apps/ai-decision-engine/ingress.yaml
+++ b/integration/apps/ai-decision-engine/ingress.yaml
@@ -1,0 +1,90 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: decision-engine-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx  
+spec:
+  rules:
+  - host: decision-engine.integration
+    http:
+      paths:
+      - path: /generate_data
+        pathType: Prefix
+        backend:
+          service:
+            name: idmgdb
+            port:
+              number: 8080
+      - path: /generate_graph
+        backend:
+          service:
+            name: idmgdb
+            port:
+              number: 8080
+      - path: /get_graph_data_wn
+        backend:
+          service:
+            name: idmgdb
+            port:
+              number: 8080
+      - path: /get_graph_data_wl
+        backend:
+          service:
+            name: idmgdb
+            port:
+              number: 8080
+      - path: /get_timeseries_graph_data_wn
+        backend:
+          service:
+            name: idmgdb
+            port:
+              number: 8080
+      - path: /get_timeseries_graph_data_wl
+        backend:
+          service:
+            name: idmgdb
+            port:
+              number: 8080
+      - path: /display
+        backend:
+          service:
+            name: idmgdc
+            port:
+              number: 8080
+      - path: /download
+        backend:
+          service:
+            name: idmgdc
+            port:
+              number: 8080
+      - path: /generate
+        backend:
+          service:
+            name: idmgdc
+            port:
+              number: 8080
+      - path: /get-response-data-json
+        backend:
+          service:
+            name: idmgpl
+            port:
+              number: 8080
+      - path: /get-response-data-xlsx
+        backend:
+          service:
+            name: idmgpl
+            port:
+              number: 8080
+      - path: /get-scores
+        backend:
+          service:
+            name: idmgpl
+            port:
+              number: 8080
+      - path: /update-config
+        backend:
+          service:
+            name: idmgpl
+            port:
+              number: 8080

--- a/integration/apps/ai-decision-engine/ingress.yaml
+++ b/integration/apps/ai-decision-engine/ingress.yaml
@@ -2,89 +2,47 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: decision-engine-ingress
-  annotations:
-    kubernetes.io/ingress.class: nginx  
+  namespace: idmg
 spec:
+  ingressClassName: nginx
   rules:
-  - host: decision-engine.integration
+  - host: database-controller.integration
     http:
       paths:
-      - path: /generate_data
+      - path: /
         pathType: Prefix
         backend:
           service:
             name: idmgdb
             port:
               number: 8080
-      - path: /generate_graph
-        backend:
-          service:
-            name: idmgdb
-            port:
-              number: 8080
-      - path: /get_graph_data_wn
-        backend:
-          service:
-            name: idmgdb
-            port:
-              number: 8080
-      - path: /get_graph_data_wl
-        backend:
-          service:
-            name: idmgdb
-            port:
-              number: 8080
-      - path: /get_timeseries_graph_data_wn
-        backend:
-          service:
-            name: idmgdb
-            port:
-              number: 8080
-      - path: /get_timeseries_graph_data_wl
-        backend:
-          service:
-            name: idmgdb
-            port:
-              number: 8080
-      - path: /display
+  - host: data-generator.integration
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
         backend:
           service:
             name: idmgdc
             port:
               number: 8080
-      - path: /download
-        backend:
-          service:
-            name: idmgdc
-            port:
-              number: 8080
-      - path: /generate
-        backend:
-          service:
-            name: idmgdc
-            port:
-              number: 8080
-      - path: /get-response-data-json
+  - host: plugin.integration
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
         backend:
           service:
             name: idmgpl
             port:
               number: 8080
-      - path: /get-response-data-xlsx
+  - host: model.integration
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
         backend:
           service:
-            name: idmgpl
-            port:
-              number: 8080
-      - path: /get-scores
-        backend:
-          service:
-            name: idmgpl
-            port:
-              number: 8080
-      - path: /update-config
-        backend:
-          service:
-            name: idmgpl
+            name: idmgml
             port:
               number: 8080

--- a/integration/apps/ai-decision-engine/neo4j-decision-engine.yaml
+++ b/integration/apps/ai-decision-engine/neo4j-decision-engine.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: neo4j
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - chart: neo4j
+      repoURL: https://neo4j.github.io/helm-charts/
+      targetRevision: 5.*.*
+      helm:
+        values: |
+          volumes.data.mode:
+            defaultStorageClass
+          neo4j.password:
+            name: neo4j-password-secret
+            key: password
+          neo4j.user:
+            name: neo4j-user-secret
+            key: user
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: idmg
+  syncPolicy:
+    automated: 
+     prune: true 
+     selfHeal: true 
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
We published idmg-decision-engine Helm chart in this [address](https://idmg-pub.gitlab.io/helm-charts/) and added that to an Argocd configuration file as was specified in other apps.

Please note:
1. The Neo4j is supposed to use secrets. 
2. Several DNS addresses pick up the namespace passed using ` helm install ... --set namespace=xxxx`

I'll be grateful for a preliminary review from your side @ktatarnikovhiro to know if we are going to the right direction.

