### PR TITLE
[minio-sse-smoke-tests] increase backoff limit to fix post-sync check

### DIFF
--- a/base/apps/kernel/manual/minio-sse-smoke-tests.yaml
+++ b/base/apps/kernel/manual/minio-sse-smoke-tests.yaml
@@ -61,4 +61,4 @@ spec:
           sources:
           - secret:
               name: glaciation-env-configuration          
-  backoffLimit: 5
+  backoffLimit: 25


### PR DESCRIPTION
This should fix post-sync minio test fails and clustercluck happens because of failing this job.