### PR TITLE
Tune Prometheus limits for Integration cluster

### DIFF
--- a/overlays/integration/kernel/kustomization.yaml
+++ b/overlays/integration/kernel/kustomization.yaml
@@ -2,3 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base/apps/kernel
+patches:
+  - path: patch-optional.yaml

--- a/overlays/integration/kernel/patch-optional.yaml
+++ b/overlays/integration/kernel/patch-optional.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata: 
+  name: monitoring-stack
+  namespace: argocd
+spec:
+  source:
+    helm:
+      valuesObject:
+        prometheus:
+          server:
+            resources:
+              limits:
+                cpu: 4
+                memory: 8Gi
+              requests:
+                cpu: 1
+                memory: 4Gi


### PR DESCRIPTION
This pull-request increses resource limits for Prometheus Server. It fixes this component. Related settings in Validation  (aka UC2) cluster was done a few our before.

Alina, please merge this pull-request on your own to avoid unexpected ArgoCD syncs on Integration cluster.