### PR TITLE
Prometheus limits for Integration cluster

### DIFF
--- a/overlays/integration/kernel/kustomization.yaml
+++ b/overlays/integration/kernel/kustomization.yaml
@@ -2,3 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base/apps/kernel
+patches:
+  - path: patch-optional.yaml

--- a/overlays/integration/kernel/patch-optional.yaml
+++ b/overlays/integration/kernel/patch-optional.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata: 
+  name: monitoring-stack
+  namespace: argocd
+spec:
+  source:
+    helm:
+      valuesObject:
+        prometheus:
+          server:
+            resources:
+              limits:
+                cpu: 1
+                memory: 4Gi
+              requests:
+                cpu: 1
+                memory: 4Gi


### PR DESCRIPTION
This pull-request increases resource limits for Prometheus Server. It fixes this component. I have set the same settings in Validation (aka UC2) cluster a few ours before. Now I create a pull-request to avoid unexpected ArgoCD syncs on Integration cluster because it may affect work of @Shockedshodan.

@Shockedshodan , please merge this pull-request on your own.