### PR TITLE
Set default resources and enforce maximum values

### DIFF
--- a/base/apps/security/gatekeeper.yaml
+++ b/base/apps/security/gatekeeper.yaml
@@ -4,6 +4,7 @@ metadata:
   name: gatekeeper
   namespace: argocd
   annotations:
+    argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/sync-wave: "-30"
   finalizers:
    - resources-finalizer.argocd.argoproj.io

--- a/base/apps/security/gatekeeper.yaml
+++ b/base/apps/security/gatekeeper.yaml
@@ -4,8 +4,7 @@ metadata:
   name: gatekeeper
   namespace: argocd
   annotations:
-    argocd.argoproj.io/hook: Sync
-    argocd.argoproj.io/sync-wave: "-8"
+    argocd.argoproj.io/sync-wave: "-30"
   finalizers:
    - resources-finalizer.argocd.argoproj.io
 spec:
@@ -14,6 +13,16 @@ spec:
     chart: gatekeeper
     repoURL: https://open-policy-agent.github.io/gatekeeper/charts
     targetRevision: 3.15.1
+    helm:
+      valuesObject:
+        audit:
+          resources:
+            limits:
+              cpu: 500m
+        controllerManager:
+          resources:
+            limits:
+              cpu: 500m
   destination:
     server: "https://kubernetes.default.svc"
     namespace: gatekeeper-system

--- a/base/apps/security/kustomization.yaml
+++ b/base/apps/security/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
   - cert-manager.yaml
   - gatekeeper.yaml
+  - set-default-resource-requests-and-limits.yaml
+  - validate-resource-requests-and-limits.yaml
   - setup-ca-and-bundle.yaml
   - trust-manager.yaml
   - vault.yaml

--- a/base/apps/security/manual/gatekeeper-smoke-tests.yaml
+++ b/base/apps/security/manual/gatekeeper-smoke-tests.yaml
@@ -94,6 +94,13 @@ spec:
 
           # Return the state of smoke test
           exit $exit_code
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 250m
+            memory: 512Mi
         securityContext:
           privileged: false
           allowPrivilegeEscalation: false

--- a/base/apps/security/set-default-resource-requests-and-limits.yaml
+++ b/base/apps/security/set-default-resource-requests-and-limits.yaml
@@ -1,0 +1,175 @@
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: add-container-resource-cpu-requests
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-30"
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  match:
+    excludedNamespaces: ["kube-*", "argocd"]
+  location: spec.containers[name:*].resources.requests.cpu
+  parameters:
+    pathTests:
+    - subPath: spec.containers[name:*].resources.requests.cpu
+      condition: MustNotExist
+    assign:
+      value: "100m"
+---
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: add-container-resource-memory-requests
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-30"
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  match:
+    excludedNamespaces: ["kube-*", "argocd"]
+  location: spec.containers[name:*].resources.requests.memory
+  parameters:
+    pathTests:
+    - subPath: spec.containers[name:*].resources.requests.memory
+      condition: MustNotExist
+    assign:
+      value: "256Mi"
+---
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: add-container-resource-cpu-limits
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-30"
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  match:
+    excludedNamespaces: ["kube-*", "argocd"]
+  location: spec.containers[name:*].resources.limits.cpu
+  parameters:
+    pathTests:
+    - subPath: spec.containers[name:*].resources.limits.cpu
+      condition: MustNotExist
+    assign:
+      value: "1"
+---
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: add-container-resource-memory-limits
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-30"
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  match:
+    excludedNamespaces: ["kube-*", "argocd"]
+  location: spec.containers[name:*].resources.limits.memory
+  parameters:
+    pathTests:
+    - subPath: spec.containers[name:*].resources.limits.memory
+      condition: MustNotExist
+    assign:
+      value: "4Gi"
+---
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: add-initcontainer-resource-cpu-requests
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-30"
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  match:
+    excludedNamespaces: ["kube-*", "argocd"]
+  location: spec.initContainers[name:*].resources.requests.cpu
+  parameters:
+    pathTests:
+    - subPath: spec.initContainers[name:*].resources.requests.cpu
+      condition: MustNotExist
+    assign:
+      value: "100m"
+---
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: add-initcontainer-resource-memory-requests
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-30"
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  match:
+    excludedNamespaces: ["kube-*", "argocd"]
+  location: spec.initContainers[name:*].resources.requests.memory
+  parameters:
+    pathTests:
+    - subPath: spec.initContainers[name:*].resources.requests.memory
+      condition: MustNotExist
+    assign:
+      value: "256Mi"
+---
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: add-initcontainer-resource-cpu-limits
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-30"
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  match:
+    excludedNamespaces: ["kube-*", "argocd"]
+  location: spec.initContainers[name:*].resources.limits.cpu
+  parameters:
+    pathTests:
+    - subPath: spec.initContainers[name:*].resources.limits.cpu
+      condition: MustNotExist
+    assign:
+      value: "1"
+---
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: add-initcontainer-resource-memory-limits
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-30"
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  match:
+    excludedNamespaces: ["kube-*", "argocd"]
+  location: spec.initContainers[name:*].resources.limits.memory
+  parameters:
+    pathTests:
+    - subPath: spec.initContainers[name:*].resources.limits.memory
+      condition: MustNotExist
+    assign:
+      value: "4Gi"

--- a/base/apps/security/set-default-resource-requests-and-limits.yaml
+++ b/base/apps/security/set-default-resource-requests-and-limits.yaml
@@ -11,7 +11,15 @@ spec:
     kinds: ["Pod"]
     versions: ["v1"]
   match:
-    excludedNamespaces: ["kube-*", "argocd"]
+    namespace:
+    - cert-manager
+    - gatekeeper-system
+    - minio-operator
+    - minio-tenant
+    - replicator
+    - spark-app
+    - spark-operator
+    - vault
   location: spec.containers[name:*].resources.requests.cpu
   parameters:
     pathTests:
@@ -33,7 +41,15 @@ spec:
     kinds: ["Pod"]
     versions: ["v1"]
   match:
-    excludedNamespaces: ["kube-*", "argocd"]
+    namespace:
+    - cert-manager
+    - gatekeeper-system
+    - minio-operator
+    - minio-tenant
+    - replicator
+    - spark-app
+    - spark-operator
+    - vault
   location: spec.containers[name:*].resources.requests.memory
   parameters:
     pathTests:
@@ -55,7 +71,15 @@ spec:
     kinds: ["Pod"]
     versions: ["v1"]
   match:
-    excludedNamespaces: ["kube-*", "argocd"]
+    namespace:
+    - cert-manager
+    - gatekeeper-system
+    - minio-operator
+    - minio-tenant
+    - replicator
+    - spark-app
+    - spark-operator
+    - vault
   location: spec.containers[name:*].resources.limits.cpu
   parameters:
     pathTests:
@@ -77,7 +101,15 @@ spec:
     kinds: ["Pod"]
     versions: ["v1"]
   match:
-    excludedNamespaces: ["kube-*", "argocd"]
+    namespace:
+    - cert-manager
+    - gatekeeper-system
+    - minio-operator
+    - minio-tenant
+    - replicator
+    - spark-app
+    - spark-operator
+    - vault
   location: spec.containers[name:*].resources.limits.memory
   parameters:
     pathTests:
@@ -99,7 +131,15 @@ spec:
     kinds: ["Pod"]
     versions: ["v1"]
   match:
-    excludedNamespaces: ["kube-*", "argocd"]
+    namespace:
+    - cert-manager
+    - gatekeeper-system
+    - minio-operator
+    - minio-tenant
+    - replicator
+    - spark-app
+    - spark-operator
+    - vault
   location: spec.initContainers[name:*].resources.requests.cpu
   parameters:
     pathTests:
@@ -121,7 +161,15 @@ spec:
     kinds: ["Pod"]
     versions: ["v1"]
   match:
-    excludedNamespaces: ["kube-*", "argocd"]
+    namespace:
+    - cert-manager
+    - gatekeeper-system
+    - minio-operator
+    - minio-tenant
+    - replicator
+    - spark-app
+    - spark-operator
+    - vault
   location: spec.initContainers[name:*].resources.requests.memory
   parameters:
     pathTests:
@@ -143,7 +191,15 @@ spec:
     kinds: ["Pod"]
     versions: ["v1"]
   match:
-    excludedNamespaces: ["kube-*", "argocd"]
+    namespace:
+    - cert-manager
+    - gatekeeper-system
+    - minio-operator
+    - minio-tenant
+    - replicator
+    - spark-app
+    - spark-operator
+    - vault
   location: spec.initContainers[name:*].resources.limits.cpu
   parameters:
     pathTests:
@@ -165,7 +221,15 @@ spec:
     kinds: ["Pod"]
     versions: ["v1"]
   match:
-    excludedNamespaces: ["kube-*", "argocd"]
+    namespace:
+    - cert-manager
+    - gatekeeper-system
+    - minio-operator
+    - minio-tenant
+    - replicator
+    - spark-app
+    - spark-operator
+    - vault
   location: spec.initContainers[name:*].resources.limits.memory
   parameters:
     pathTests:

--- a/base/apps/security/set-default-resource-requests-and-limits.yaml
+++ b/base/apps/security/set-default-resource-requests-and-limits.yaml
@@ -3,6 +3,7 @@ kind: Assign
 metadata:
   name: add-container-resource-cpu-requests
   annotations:
+    argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "-30"
 spec:

--- a/base/apps/security/validate-resource-requests-and-limits.yaml
+++ b/base/apps/security/validate-resource-requests-and-limits.yaml
@@ -544,7 +544,15 @@ spec:
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]
-    excludedNamespaces: ["kube-*", "argocd"]
+    namespace:
+    - cert-manager
+    - gatekeeper-system
+    - minio-operator
+    - minio-tenant
+    - replicator
+    - spark-app
+    - spark-operator
+    - vault
   parameters:
     cpu: "1"
     memory: "4Gi"
@@ -561,7 +569,15 @@ spec:
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]
-    excludedNamespaces: ["kube-*", "argocd"]
+    namespace:
+    - cert-manager
+    - gatekeeper-system
+    - minio-operator
+    - minio-tenant
+    - replicator
+    - spark-app
+    - spark-operator
+    - vault
   parameters:
     cpu: "2"
     memory: "8Gi"

--- a/base/apps/security/validate-resource-requests-and-limits.yaml
+++ b/base/apps/security/validate-resource-requests-and-limits.yaml
@@ -1,0 +1,567 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8scontainerrequests
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-30"
+    metadata.gatekeeper.sh/title: "Container Requests"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: >-
+      Requires containers to have memory and CPU requests set and constrains
+      requests to be within the specified maximum values.
+
+      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sContainerRequests
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            cpu:
+              description: "The maximum allowed cpu request on a Pod, exclusive."
+              type: string
+            memory:
+              description: "The maximum allowed memory request on a Pod, exclusive."
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8scontainerrequests
+
+        import data.lib.exempt_container.is_exempt
+
+        missing(obj, field) = true {
+          not obj[field]
+        }
+
+        missing(obj, field) = true {
+          obj[field] == ""
+        }
+
+        canonify_cpu(orig) = new {
+          is_number(orig)
+          new := orig * 1000
+        }
+
+        canonify_cpu(orig) = new {
+          not is_number(orig)
+          endswith(orig, "m")
+          new := to_number(replace(orig, "m", ""))
+        }
+
+        canonify_cpu(orig) = new {
+          not is_number(orig)
+          not endswith(orig, "m")
+          regex.match("^[0-9]+(\\.[0-9]+)?$", orig)
+          new := to_number(orig) * 1000
+        }
+
+        # 10 ** 21
+        mem_multiple("E") = 1000000000000000000000 { true }
+
+        # 10 ** 18
+        mem_multiple("P") = 1000000000000000000 { true }
+
+        # 10 ** 15
+        mem_multiple("T") = 1000000000000000 { true }
+
+        # 10 ** 12
+        mem_multiple("G") = 1000000000000 { true }
+
+        # 10 ** 9
+        mem_multiple("M") = 1000000000 { true }
+
+        # 10 ** 6
+        mem_multiple("k") = 1000000 { true }
+
+        # 10 ** 3
+        mem_multiple("") = 1000 { true }
+
+        # Kubernetes accepts millibyte precision when it probably shouldn't.
+        # https://github.com/kubernetes/kubernetes/issues/28741
+        # 10 ** 0
+        mem_multiple("m") = 1 { true }
+
+        # 1000 * 2 ** 10
+        mem_multiple("Ki") = 1024000 { true }
+
+        # 1000 * 2 ** 20
+        mem_multiple("Mi") = 1048576000 { true }
+
+        # 1000 * 2 ** 30
+        mem_multiple("Gi") = 1073741824000 { true }
+
+        # 1000 * 2 ** 40
+        mem_multiple("Ti") = 1099511627776000 { true }
+
+        # 1000 * 2 ** 50
+        mem_multiple("Pi") = 1125899906842624000 { true }
+
+        # 1000 * 2 ** 60
+        mem_multiple("Ei") = 1152921504606846976000 { true }
+
+        get_suffix(mem) = suffix {
+          not is_string(mem)
+          suffix := ""
+        }
+
+        get_suffix(mem) = suffix {
+          is_string(mem)
+          count(mem) > 0
+          suffix := substring(mem, count(mem) - 1, -1)
+          mem_multiple(suffix)
+        }
+
+        get_suffix(mem) = suffix {
+          is_string(mem)
+          count(mem) > 1
+          suffix := substring(mem, count(mem) - 2, -1)
+          mem_multiple(suffix)
+        }
+
+        get_suffix(mem) = suffix {
+          is_string(mem)
+          count(mem) > 1
+          not mem_multiple(substring(mem, count(mem) - 1, -1))
+          not mem_multiple(substring(mem, count(mem) - 2, -1))
+          suffix := ""
+        }
+
+        get_suffix(mem) = suffix {
+          is_string(mem)
+          count(mem) == 1
+          not mem_multiple(substring(mem, count(mem) - 1, -1))
+          suffix := ""
+        }
+
+        get_suffix(mem) = suffix {
+          is_string(mem)
+          count(mem) == 0
+          suffix := ""
+        }
+
+        canonify_mem(orig) = new {
+          is_number(orig)
+          new := orig * 1000
+        }
+
+        canonify_mem(orig) = new {
+          not is_number(orig)
+          suffix := get_suffix(orig)
+          raw := replace(orig, suffix, "")
+          regex.match("^[0-9]+(\\.[0-9]+)?$", raw)
+          new := to_number(raw) * mem_multiple(suffix)
+        }
+
+        violation[{"msg": msg}] {
+          general_violation[{"msg": msg, "field": "containers"}]
+        }
+
+        violation[{"msg": msg}] {
+          general_violation[{"msg": msg, "field": "initContainers"}]
+        }
+
+        # Ephemeral containers not checked as it is not possible to set field.
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          cpu_orig := container.resources.requests.cpu
+          not canonify_cpu(cpu_orig)
+          msg := sprintf("container <%v> cpu request <%v> could not be parsed", [container.name, cpu_orig])
+        }
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          mem_orig := container.resources.requests.memory
+          not canonify_mem(mem_orig)
+          msg := sprintf("container <%v> memory request <%v> could not be parsed", [container.name, mem_orig])
+        }
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          not container.resources
+          msg := sprintf("container <%v> has no resource requests", [container.name])
+        }
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          not container.resources.requests
+          msg := sprintf("container <%v> has no resource requests", [container.name])
+        }
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          missing(container.resources.requests, "cpu")
+          msg := sprintf("container <%v> has no cpu request", [container.name])
+        }
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          missing(container.resources.requests, "memory")
+          msg := sprintf("container <%v> has no memory request", [container.name])
+        }
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          cpu_orig := container.resources.requests.cpu
+          cpu := canonify_cpu(cpu_orig)
+          max_cpu_orig := input.parameters.cpu
+          max_cpu := canonify_cpu(max_cpu_orig)
+          cpu > max_cpu
+          msg := sprintf("container <%v> cpu request <%v> is higher than the maximum allowed of <%v>", [container.name, cpu_orig, max_cpu_orig])
+        }
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          mem_orig := container.resources.requests.memory
+          mem := canonify_mem(mem_orig)
+          max_mem_orig := input.parameters.memory
+          max_mem := canonify_mem(max_mem_orig)
+          mem > max_mem
+          msg := sprintf("container <%v> memory request <%v> is higher than the maximum allowed of <%v>", [container.name, mem_orig, max_mem_orig])
+        }
+      libs:
+        - |
+          package lib.exempt_container
+
+          is_exempt(container) {
+              exempt_images := object.get(object.get(input, "parameters", {}), "exemptImages", [])
+              img := container.image
+              exemption := exempt_images[_]
+              _matches_exemption(img, exemption)
+          }
+
+          _matches_exemption(img, exemption) {
+              not endswith(exemption, "*")
+              exemption == img
+          }
+
+          _matches_exemption(img, exemption) {
+              endswith(exemption, "*")
+              prefix := trim_suffix(exemption, "*")
+              startswith(img, prefix)
+          }
+---
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8scontainerlimits
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-30"
+    metadata.gatekeeper.sh/title: "Container Limits"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: >-
+      Requires containers to have memory and CPU limits set and constrains
+      limits to be within the specified maximum values.
+
+      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sContainerLimits
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            exemptImages:
+              description: >-
+                Any container that uses an image that matches an entry in this list will be excluded
+                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
+
+                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
+                in order to avoid unexpectedly exempting images from an untrusted repository.
+              type: array
+              items:
+                type: string
+            cpu:
+              description: "The maximum allowed cpu limit on a Pod, exclusive."
+              type: string
+            memory:
+              description: "The maximum allowed memory limit on a Pod, exclusive."
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8scontainerlimits
+
+        import data.lib.exempt_container.is_exempt
+
+        missing(obj, field) = true {
+          not obj[field]
+        }
+
+        missing(obj, field) = true {
+          obj[field] == ""
+        }
+
+        canonify_cpu(orig) = new {
+          is_number(orig)
+          new := orig * 1000
+        }
+
+        canonify_cpu(orig) = new {
+          not is_number(orig)
+          endswith(orig, "m")
+          new := to_number(replace(orig, "m", ""))
+        }
+
+        canonify_cpu(orig) = new {
+          not is_number(orig)
+          not endswith(orig, "m")
+          regex.match("^[0-9]+(\\.[0-9]+)?$", orig)
+          new := to_number(orig) * 1000
+        }
+
+        # 10 ** 21
+        mem_multiple("E") = 1000000000000000000000 { true }
+
+        # 10 ** 18
+        mem_multiple("P") = 1000000000000000000 { true }
+
+        # 10 ** 15
+        mem_multiple("T") = 1000000000000000 { true }
+
+        # 10 ** 12
+        mem_multiple("G") = 1000000000000 { true }
+
+        # 10 ** 9
+        mem_multiple("M") = 1000000000 { true }
+
+        # 10 ** 6
+        mem_multiple("k") = 1000000 { true }
+
+        # 10 ** 3
+        mem_multiple("") = 1000 { true }
+
+        # Kubernetes accepts millibyte precision when it probably shouldn't.
+        # https://github.com/kubernetes/kubernetes/issues/28741
+        # 10 ** 0
+        mem_multiple("m") = 1 { true }
+
+        # 1000 * 2 ** 10
+        mem_multiple("Ki") = 1024000 { true }
+
+        # 1000 * 2 ** 20
+        mem_multiple("Mi") = 1048576000 { true }
+
+        # 1000 * 2 ** 30
+        mem_multiple("Gi") = 1073741824000 { true }
+
+        # 1000 * 2 ** 40
+        mem_multiple("Ti") = 1099511627776000 { true }
+
+        # 1000 * 2 ** 50
+        mem_multiple("Pi") = 1125899906842624000 { true }
+
+        # 1000 * 2 ** 60
+        mem_multiple("Ei") = 1152921504606846976000 { true }
+
+        get_suffix(mem) = suffix {
+          not is_string(mem)
+          suffix := ""
+        }
+
+        get_suffix(mem) = suffix {
+          is_string(mem)
+          count(mem) > 0
+          suffix := substring(mem, count(mem) - 1, -1)
+          mem_multiple(suffix)
+        }
+
+        get_suffix(mem) = suffix {
+          is_string(mem)
+          count(mem) > 1
+          suffix := substring(mem, count(mem) - 2, -1)
+          mem_multiple(suffix)
+        }
+
+        get_suffix(mem) = suffix {
+          is_string(mem)
+          count(mem) > 1
+          not mem_multiple(substring(mem, count(mem) - 1, -1))
+          not mem_multiple(substring(mem, count(mem) - 2, -1))
+          suffix := ""
+        }
+
+        get_suffix(mem) = suffix {
+          is_string(mem)
+          count(mem) == 1
+          not mem_multiple(substring(mem, count(mem) - 1, -1))
+          suffix := ""
+        }
+
+        get_suffix(mem) = suffix {
+          is_string(mem)
+          count(mem) == 0
+          suffix := ""
+        }
+
+        canonify_mem(orig) = new {
+          is_number(orig)
+          new := orig * 1000
+        }
+
+        canonify_mem(orig) = new {
+          not is_number(orig)
+          suffix := get_suffix(orig)
+          raw := replace(orig, suffix, "")
+          regex.match("^[0-9]+(\\.[0-9]+)?$", raw)
+          new := to_number(raw) * mem_multiple(suffix)
+        }
+
+        violation[{"msg": msg}] {
+          general_violation[{"msg": msg, "field": "containers"}]
+        }
+
+        violation[{"msg": msg}] {
+          general_violation[{"msg": msg, "field": "initContainers"}]
+        }
+
+        # Ephemeral containers not checked as it is not possible to set field.
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          cpu_orig := container.resources.limits.cpu
+          not canonify_cpu(cpu_orig)
+          msg := sprintf("container <%v> cpu limit <%v> could not be parsed", [container.name, cpu_orig])
+        }
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          mem_orig := container.resources.limits.memory
+          not canonify_mem(mem_orig)
+          msg := sprintf("container <%v> memory limit <%v> could not be parsed", [container.name, mem_orig])
+        }
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          not container.resources
+          msg := sprintf("container <%v> has no resource limits", [container.name])
+        }
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          not container.resources.limits
+          msg := sprintf("container <%v> has no resource limits", [container.name])
+        }
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          missing(container.resources.limits, "cpu")
+          msg := sprintf("container <%v> has no cpu limit", [container.name])
+        }
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          missing(container.resources.limits, "memory")
+          msg := sprintf("container <%v> has no memory limit", [container.name])
+        }
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          cpu_orig := container.resources.limits.cpu
+          cpu := canonify_cpu(cpu_orig)
+          max_cpu_orig := input.parameters.cpu
+          max_cpu := canonify_cpu(max_cpu_orig)
+          cpu > max_cpu
+          msg := sprintf("container <%v> cpu limit <%v> is higher than the maximum allowed of <%v>", [container.name, cpu_orig, max_cpu_orig])
+        }
+
+        general_violation[{"msg": msg, "field": field}] {
+          container := input.review.object.spec[field][_]
+          not is_exempt(container)
+          mem_orig := container.resources.limits.memory
+          mem := canonify_mem(mem_orig)
+          max_mem_orig := input.parameters.memory
+          max_mem := canonify_mem(max_mem_orig)
+          mem > max_mem
+          msg := sprintf("container <%v> memory limit <%v> is higher than the maximum allowed of <%v>", [container.name, mem_orig, max_mem_orig])
+        }
+      libs:
+        - |
+          package lib.exempt_container
+
+          is_exempt(container) {
+              exempt_images := object.get(object.get(input, "parameters", {}), "exemptImages", [])
+              img := container.image
+              exemption := exempt_images[_]
+              _matches_exemption(img, exemption)
+          }
+
+          _matches_exemption(img, exemption) {
+              not endswith(exemption, "*")
+              exemption == img
+          }
+
+          _matches_exemption(img, exemption) {
+              endswith(exemption, "*")
+              prefix := trim_suffix(exemption, "*")
+              startswith(img, prefix)
+          }
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sContainerRequests
+metadata:
+  name: container-must-have-requests
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-30"
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces: ["kube-*", "argocd"]
+  parameters:
+    cpu: "1"
+    memory: "4Gi"
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sContainerLimits
+metadata:
+  name: container-must-have-limits
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-30"
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces: ["kube-*", "argocd"]
+  parameters:
+    cpu: "2"
+    memory: "8Gi"

--- a/base/apps/security/validate-resource-requests-and-limits.yaml
+++ b/base/apps/security/validate-resource-requests-and-limits.yaml
@@ -3,6 +3,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8scontainerrequests
   annotations:
+    argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "-30"
     metadata.gatekeeper.sh/title: "Container Requests"


### PR DESCRIPTION
Following up to the request to set resource requests and limits to all containers, I have defined a Gatekeeper mutation that set defaults values for CPU and memory requests and limits.
While I was at it, I also added validation rules enforcing the presence of the requests and limits, and also their maximum values allowed (from the [OPA Gatekeeper Library](https://open-policy-agent.github.io/gatekeeper-library/website/)).

Here is a summary of the changes:

1. Anticipate the deployment of Gatekeeper as soon as possible to set defaults values and validate all requests sent to the Kubernetes API
2. Set resources requests and limits on all Gatekeeper services (these are not affected by the mutation)
3. Assignment mutations for setting default requests and limits when they are missing
4. Validate presence of resources information and enforce maximum values for requests and limits