### PR TITLE
Fix Vault and MinIO tenant Web UIs

### DIFF
--- a/base/apps/security/minio-tenant.yaml
+++ b/base/apps/security/minio-tenant.yaml
@@ -24,8 +24,7 @@ spec:
 
         tenant:
           name: glaciation
-          # Kubernetes secret name that contains MinIO environment variable
-          # configurations
+          # Kubernetes secret name that contains the root MinIO user credentials
           configuration:
             name: glaciation-env-configuration
           pools:
@@ -133,7 +132,8 @@ spec:
             #   # NOTE: To make sure the certificate is trusted by clients we should use
             #   # something like Let's Encrypt
             #   cert-manager.io/cluster-issuer: "private-ca-issuer"
-              nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+              nginx.org/redirect-to-https: "true"
+              nginx.org/ssl-services: "minio"
             # tls:
             # - hosts:
             #   - glaciation-tenant.integration
@@ -148,7 +148,8 @@ spec:
             #   # NOTE: To make sure the certificate is trusted by clients we should use
             #   # something like Let's Encrypt
             #   cert-manager.io/cluster-issuer: "private-ca-issuer"
-              nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+              nginx.org/redirect-to-https: "true"
+              nginx.org/ssl-services: "glaciation-console"
             # tls:
             # - hosts:
             #   - glaciation-tenant-console.integration

--- a/base/apps/security/vault.yaml
+++ b/base/apps/security/vault.yaml
@@ -68,7 +68,8 @@ spec:
             #   # NOTE: To make sure the certificate is trusted by clients we should use
             #   # something like Let's Encrypt
             #   cert-manager.io/cluster-issuer: "private-ca-issuer"
-              nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+              nginx.org/redirect-to-https: "true"
+              nginx.org/ssl-services: "vault"
             # tls:
             # - hosts:
             #   - vault.integration


### PR DESCRIPTION
In their current state, Vault and MinIO tenant Web UIs return the "Client sent an HTTP request to an HTTPS server" error.

This happens despite providing the `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` annotation to the Vault and MinIO tenant Ingresses, so with this patch I update their annotations to make sure NGINX redirects their requests to HTTPS.

From the test I have done on the integration cluster, this completely solves the primary issue. However, the MinIO Console is still proving problematic. Indeed, while the MinIO Console login page is now accessible, after logging in, the interaction with the session endpoint responses with `{"detailedMessage":"Access Denied.","message":"invalid session"}`  and leaves us with a blank page. To me this seems like a MinIO Console bug caused by using an HTTP ingress for the HTTPS server, so I will reach out to the MinIO community to get support on this.

I run a few tests in a local Minikube environment and with HTTP I can reproduce the same issue, however with HTTPS the MinIO Console works. So, would it be possible to update the [NGINX configuration](docs/load-balancer/kubernetes.conf) to support HTTPS incoming traffic?