### PR TITLE
Anonymous read-only mode for Jenkins

### DIFF
--- a/base/apps/base/jenkins.yaml
+++ b/base/apps/base/jenkins.yaml
@@ -23,6 +23,8 @@ spec:
           admin:
             user: admin          
             password: jenkins
+          JCasC:
+            authorizationStrategy: "loggedInUsersCanDoAnything:\n  allowAnonymousRead: true"
         ingress:
           enabled: false
         persistence:


### PR DESCRIPTION
Now you can access Jenkins without authentication in read-only mode.