### PR TITLE
Kustomize Swarm Agent

### DIFF
--- a/base/apps/dkg-engine/kustomization.yaml
+++ b/base/apps/dkg-engine/kustomization.yaml
@@ -12,5 +12,6 @@ resources:
   - nats.nack.yaml
   - nats.nats.yaml
   - nats.stream.yaml
+  - swarm-agent.yaml
   - dkg-tenant.yaml
   - replica-service.yaml

--- a/overlays/validation/dkg-engine/patch-optional.yaml
+++ b/overlays/validation/dkg-engine/patch-optional.yaml
@@ -67,6 +67,17 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  name: swarm-agent
+  namespace: argocd
+spec:
+  source:
+    helm:
+      valuesObject:
+        ingressHostName: swarm-agent.validation
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
   name: replica-service
   namespace: argocd
 spec:


### PR DESCRIPTION
Pull request #90 does not contain a Kustomize configuration for Swarm Agent. This is why the agent was not deployed. This pull request adds the configuration. Now, Swarm Agent will be delivered to both clusters.