### PR TITLE
make the service type NodePort

### DIFF
--- a/base/apps/dkg-engine/swarm-agent.yaml
+++ b/base/apps/dkg-engine/swarm-agent.yaml
@@ -17,8 +17,6 @@ spec:
     helm:
       valuesObject:
         ingressHostName: swarm-agent.integration
-        service:
-          type: ClusterIP
   syncPolicy:
     automated:
      prune: true


### PR DESCRIPTION
Removing these two lines assures that the type specified in the `values.yaml` of `swarm-agent` is used. Which is `NodePort` at the moment.