### PR TITLE
Enable ingress for Loki

### DIFF
--- a/base/apps/kernel/monitoring-stack.yaml
+++ b/base/apps/kernel/monitoring-stack.yaml
@@ -173,6 +173,13 @@ spec:
                   stream: kube-events
                 url: http://monitoring-stack-loki:3100/loki/api/v1/push
 
+        loki-stack:
+          gateway:
+            ingress:
+              enabled: true
+              ingressClassName: nginx
+              host: loki.integration
+
         grafana:
           adminPassword: donkeyhot
           ingress:

--- a/overlays/validation/kernel/patch-optional.yaml
+++ b/overlays/validation/kernel/patch-optional.yaml
@@ -39,3 +39,18 @@ spec:
             global:
               external_labels:
                 cluster: validation
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: monitoring-stack
+  namespace: argocd
+spec:
+  source:
+    helm:
+      valuesObject:
+        loki-stack:
+          gateway:
+            ingress:
+              host: loki.integration


### PR DESCRIPTION
We need it to export logs generated by UC4.